### PR TITLE
List of background tasks in page server.

### DIFF
--- a/background-tasks.md
+++ b/background-tasks.md
@@ -1,0 +1,38 @@
+# Eviction
+
+ Write out in-memory layer to disk, into a delta layer.
+
+- To release memory
+- To make it possible to advance disk_consistent_lsn and allow the WAL
+  service to release some WAL.
+
+- Triggered if we are short on memory
+- Or if the oldest in-memory layer is so old that it's holding back
+  the WAL service from removing old WAL
+
+# Materialization
+
+Create a new image layer of a segment, by performing WAL redo
+
+- To reduce the amount of WAL that needs to be replayed on a GetPage request.
+- To allow garbage collection of old layers
+
+- Triggered by distance to last full image of a page
+
+# Coalescing
+
+Replace N consecutive layers of a segment with one larger layer.
+
+- To reduce the number of small files that needs to be uploaded to S3
+
+
+# Bundling
+
+Zip together multiple small files belonging to different segments.
+
+- To reduce the number of small files that needs to be uploaded to S3
+
+
+# Garbage collection
+
+Remove a layer that's older than the GC horizon, and isn't needed anymore.


### PR DESCRIPTION
The page server has several different background tasks it needs to or can perform on the layers. I've tried to list them here, based on the recent discussion on the discord channel.

This description and the terms don't match the actual code on 'main' currently. On 'main', the checkpointer thread performs 'Eviction' and 'Materialization' tasks together. The GC thread perfoms 'Garbage Collection', and 'Coalescing' and 'Bundling' are not performed at all.